### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A small, very simple library for opening, closing, approving and commenting on p
 
 ## Usage
 
+[![Clojars Project](https://img.shields.io/clojars/v/eamonnsullivan/github-pr-lib.svg)](https://clojars.org/eamonnsullivan/github-pr-lib)
+
 You will need a Github access token with `repo` permissions. This is one way to provide that value:
 ```
 (def token (System/getenv "GITHUB_ACCESS_TOKEN"))

--- a/src/eamonnsullivan/github_pr_lib.clj
+++ b/src/eamonnsullivan/github_pr_lib.clj
@@ -124,7 +124,8 @@
 (defn get-pull-request-id
   "Find the unique ID of a pull request on the repository at the
   provided url. Set must-be-open? to true to filter the pull requests
-  to those with a status of open. Returns nil if not found."
+  to those with a status of open. Throws a runtime exception if the
+  pull request isn't found."
   ([access-token url]
    (get-pull-request-id access-token url false))
   ([access-token url must-be-open?]


### PR DESCRIPTION
Fix the doc string for get-pull-request-id to note that it throws an exception, not returns nil, if the pull request isn't found. Also, add a Clojars badge in the readme that's kept updated automatically with the latest version.