### PR TITLE
Documentation fixes, CI tweaks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,17 +18,26 @@ jobs:
     - name: Prepare Clojure
       uses: DeLaGuardo/setup-clojure@master
       with:
-        cli: '1.10.1.469'
-    - name: test
-      run: clojure -A:test:runner -M:runner
+        cli: '1.10.1.708'
+    - name: Run unit tests
+      run: clojure -A:test:runner
     - name: Check for minimum coverage
       run: clojure -A:test:cloverage
-    - name: pom
+    - name: Update pom.xml
       run: clojure -Spom
-    - name: build
-      run: clojure -A:jar -M:jar
-    - name: deploy
-      run: clojure -A:deploy -M:deploy
+    - name: Build
+      run: clojure -A:jar
+    - name: Deploy
+      run: clojure -A:deploy
       env:
         CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
         CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+    - name: Extract release id
+      run: echo "release_version=\"v`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`\"" >> $GITHUB_ENV
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: $release_version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Prepare Clojure
       uses: DeLaGuardo/setup-clojure@master
       with:
-        cli: '1.10.1.469'
+        cli: '1.10.1.708'
     - name: Run tests
-      run: clojure -A:test:runner -M:runner
+      run: clojure -A:test:runner
     - name: Check for minimum coverage
       run: clojure -A:test:cloverage

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A small, very simple library for opening, closing, approving and commenting on p
 
 ## Usage
 
+[![Clojars Project](https://img.shields.io/clojars/v/eamonnsullivan/github-pr-lib.svg)](https://clojars.org/eamonnsullivan/github-pr-lib)
+
 You will need a Github access token with `repo` permissions. This is one way to provide that value:
 ```
 (def token (System/getenv "GITHUB_ACCESS_TOKEN"))

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>eamonnsullivan</groupId>
   <artifactId>github-pr-lib</artifactId>
-  <version>0.0.13</version>
+  <version>0.0.14</version>
   <name>github-pr-lib</name>
   <description>Small library for creating and modifying Github pull requests.</description>
   <url>https://github.com/eamonnsullivan/github-pr-lib</url>

--- a/src/eamonnsullivan/github_pr_lib.clj
+++ b/src/eamonnsullivan/github_pr_lib.clj
@@ -124,7 +124,8 @@
 (defn get-pull-request-id
   "Find the unique ID of a pull request on the repository at the
   provided url. Set must-be-open? to true to filter the pull requests
-  to those with a status of open. Returns nil if not found."
+  to those with a status of open. Throws a runtime exception if the
+  pull request isn't found."
   ([access-token url]
    (get-pull-request-id access-token url false))
   ([access-token url must-be-open?]


### PR DESCRIPTION
Fix the docstring for `get-pull-request-id` to note that it throws an exception, not just return nil, if the pull request isn't found.

Add a badge on the README page with the current version.

Tag the commits when we successfully deploy a release.

Update the tools.cli version in the actions.