### PR TITLE
Refactor GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [0.0.17]-2020-10-16
 - Remove some redundancy from the GraphQL, and rearranged them (alphabetically) to make it easier to spot these.
-- Remove references to maintainerCanModify. It seems like we can't change this. Mutations have no affect and it is always false.
+- Remove references to maintainerCanModify. It seems like we can't change this. Mutations have no effect and it is always false.
 ## [0.0.16]-2020-10-15
 - Fixes docstrings for some methods
 - Tweaks to CI workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [0.0.17]-2020-10-16
+- Remove some redundancy from the GraphQL, and rearranged them (alphabetically) to make it easier to spot these.
 ## [0.0.16]-2020-10-15
 - Fixes docstrings for some methods
 - Tweaks to CI workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [0.0.17]-2020-10-16
 - Remove some redundancy from the GraphQL, and rearranged them (alphabetically) to make it easier to spot these.
+- Remove references to maintainerCanModify. It seems like we can't change this. Mutations have no affect and it is always false.
 ## [0.0.16]-2020-10-15
 - Fixes docstrings for some methods
 - Tweaks to CI workflow

--- a/README.md
+++ b/README.md
@@ -19,19 +19,17 @@ All of these methods return a map of information about the new or updated pull r
               :body "The body of the pull request"
               :base "main or master, usually"
               :branch "the name of the branch you want to merge"
-              :draft true
-              :maintainerCanModify true})
+              :draft true})
 (def new-pr-url (:permalink (create-pull-request
                  token
                  "https://github.com/eamonnsullivan/github-pr-lib" options)))
 ```
-The `:title`, `:base` and `:branch` are mandatory. You can omit the `:body`, and the `:draft` and `:maintainerCanModify` options default to true.
+The `:title`, `:base` and `:branch` are mandatory. You can omit the `:body`, and `:draft` defaults to true.
 
 ### Update a pull request
 ```
 (def updated {:title "A new title"
-              :body "A new body"
-              :maintainerCanModify false})
+              :body "A new body"})
 (update-pull-request token new-pr-url updated)
 ```
 ### Mark a pull request as ready for review

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>eamonnsullivan</groupId>
   <artifactId>github-pr-lib</artifactId>
-  <version>0.0.16</version>
+  <version>0.0.17</version>
   <name>github-pr-lib</name>
   <description>Small library for creating and modifying Github pull requests.</description>
   <url>https://github.com/eamonnsullivan/github-pr-lib</url>

--- a/resources/graphql/close-pull-request-mutation.graphql
+++ b/resources/graphql/close-pull-request-mutation.graphql
@@ -1,42 +1,30 @@
 mutation ClosePullRequest ($pullRequestId: ID!) {
   closePullRequest(input: {pullRequestId: $pullRequestId}) {
     pullRequest {
-      id
-      title
-      body
-      baseRefOid
-      headRefOid
-      permalink
+      additions
       author {
         login
         url
       }
-      closed
-      isDraft
-      merged
-      mergeable
-      number
-      repository {
-        id
-        url
-      }
-      state
-      additions
-      deletions
+      baseRefOid
+      body
       changedFiles
       checksResourcePath
       closed
       closedAt
       createdAt
+      deletions
+      headRefOid
+      id
       isDraft
       maintainerCanModify
+      mergeable
       mergeCommit {
         abbreviatedOid
         message
         messageBody
         messageHeadline
       }
-      mergeable
       merged
       mergedAt
       mergedBy {
@@ -45,8 +33,13 @@ mutation ClosePullRequest ($pullRequestId: ID!) {
       }
       number
       permalink
+      repository {
+        id
+        url
+      }
       revertUrl
       state
+      title
     }
   }
 }

--- a/resources/graphql/create-pull-request-mutation.graphql
+++ b/resources/graphql/create-pull-request-mutation.graphql
@@ -10,42 +10,30 @@ mutation CreatePullRequest
       maintainerCanModify: $maintainerCanModify
     }) {
     pullRequest {
-      id
-      title
-      body
-      baseRefOid
-      headRefOid
-      permalink
+      additions
       author {
         login
         url
       }
-      closed
-      isDraft
-      merged
-      mergeable
-      number
-      repository {
-        id
-        url
-      }
-      state
-      additions
-      deletions
+      baseRefOid
+      body
       changedFiles
       checksResourcePath
       closed
       closedAt
       createdAt
+      deletions
+      headRefOid
+      id
       isDraft
       maintainerCanModify
+      mergeable
       mergeCommit {
         abbreviatedOid
         message
         messageBody
         messageHeadline
       }
-      mergeable
       merged
       mergedAt
       mergedBy {
@@ -54,8 +42,13 @@ mutation CreatePullRequest
       }
       number
       permalink
+      repository {
+        id
+        url
+      }
       revertUrl
       state
+      title
     }
   }
 }

--- a/resources/graphql/create-pull-request-mutation.graphql
+++ b/resources/graphql/create-pull-request-mutation.graphql
@@ -1,13 +1,12 @@
 mutation CreatePullRequest
-($title: String!, $body: String, $repositoryId: ID!, $base: String!, $branch: String!, $draft: Boolean!, $maintainerCanModify: Boolean) {
+($title: String!, $body: String, $repositoryId: ID!, $base: String!, $branch: String!, $draft: Boolean!) {
   createPullRequest(input: {
       title: $title,
       body: $body,
       repositoryId: $repositoryId,
       baseRefName: $base,
       headRefName: $branch,
-      draft: $draft,
-      maintainerCanModify: $maintainerCanModify
+      draft: $draft
     }) {
     pullRequest {
       additions

--- a/resources/graphql/mark-ready-for-review-mutation.graphql
+++ b/resources/graphql/mark-ready-for-review-mutation.graphql
@@ -1,42 +1,30 @@
 mutation MarkReadyForReview ($pullRequestId: ID!) {
   markPullRequestReadyForReview(input: {pullRequestId: $pullRequestId}) {
     pullRequest {
-      id
-      title
-      body
-      baseRefOid
-      headRefOid
-      permalink
+      additions
       author {
         login
         url
       }
-      closed
-      isDraft
-      merged
-      mergeable
-      number
-      repository {
-        id
-        url
-      }
-      state
-      additions
-      deletions
+      baseRefOid
+      body
       changedFiles
       checksResourcePath
       closed
       closedAt
       createdAt
+      deletions
+      headRefOid
+      id
       isDraft
       maintainerCanModify
+      mergeable
       mergeCommit {
         abbreviatedOid
         message
         messageBody
         messageHeadline
       }
-      mergeable
       merged
       mergedAt
       mergedBy {
@@ -45,8 +33,13 @@ mutation MarkReadyForReview ($pullRequestId: ID!) {
       }
       number
       permalink
+      repository {
+        id
+        url
+      }
       revertUrl
       state
+      title
     }
   }
 }

--- a/resources/graphql/merge-pull-request-mutation.graphql
+++ b/resources/graphql/merge-pull-request-mutation.graphql
@@ -6,42 +6,30 @@ mutation MergePullRequest ($pullRequestId: ID!, $title: String, $body: String, $
       authorEmail: $authorEmail,
       expectedHeadOid: $expectedHeadRef}) {
     pullRequest {
-      id
-      title
-      body
-      baseRefOid
-      headRefOid
-      permalink
+      additions
       author {
         login
         url
       }
-      closed
-      isDraft
-      merged
-      mergeable
-      number
-      repository {
-        id
-        url
-      }
-      state
-      additions
-      deletions
+      baseRefOid
+      body
       changedFiles
       checksResourcePath
       closed
       closedAt
       createdAt
+      deletions
+      headRefOid
+      id
       isDraft
       maintainerCanModify
+      mergeable
       mergeCommit {
         abbreviatedOid
         message
         messageBody
         messageHeadline
       }
-      mergeable
       merged
       mergedAt
       mergedBy {
@@ -50,8 +38,13 @@ mutation MergePullRequest ($pullRequestId: ID!, $title: String, $body: String, $
       }
       number
       permalink
+      repository {
+        id
+        url
+      }
       revertUrl
       state
+      title
     }
   }
 }

--- a/resources/graphql/pull-request-query.graphql
+++ b/resources/graphql/pull-request-query.graphql
@@ -1,42 +1,30 @@
 query PullRequestQuery ($pullRequestId: ID!) {
   node(id: $pullRequestId) {
     ... on PullRequest {
-      id
-      title
-      body
-      baseRefOid
-      headRefOid
-      permalink
+      additions
       author {
         login
         url
       }
-      closed
-      isDraft
-      merged
-      mergeable
-      number
-      repository {
-        id
-        url
-      }
-      state
-      additions
-      deletions
+      baseRefOid
+      body
       changedFiles
       checksResourcePath
       closed
       closedAt
       createdAt
+      deletions
+      headRefOid
+      id
       isDraft
       maintainerCanModify
+      mergeable
       mergeCommit {
         abbreviatedOid
         message
         messageBody
         messageHeadline
       }
-      mergeable
       merged
       mergedAt
       mergedBy {
@@ -45,8 +33,13 @@ query PullRequestQuery ($pullRequestId: ID!) {
       }
       number
       permalink
+      repository {
+        id
+        url
+      }
       revertUrl
       state
+      title
     }
   }
 }

--- a/resources/graphql/reopen-pull-request-mutation.graphql
+++ b/resources/graphql/reopen-pull-request-mutation.graphql
@@ -1,42 +1,30 @@
 mutation ReopenPullRequest ($pullRequestId: ID!) {
   reopenPullRequest(input: {pullRequestId: $pullRequestId}) {
     pullRequest {
-      id
-      title
-      body
-      baseRefOid
-      headRefOid
-      permalink
+      additions
       author {
         login
         url
       }
-      closed
-      isDraft
-      merged
-      mergeable
-      number
-      repository {
-        id
-        url
-      }
-      state
-      additions
-      deletions
+      baseRefOid
+      body
       changedFiles
       checksResourcePath
       closed
       closedAt
       createdAt
+      deletions
+      headRefOid
+      id
       isDraft
       maintainerCanModify
+      mergeable
       mergeCommit {
         abbreviatedOid
         message
         messageBody
         messageHeadline
       }
-      mergeable
       merged
       mergedAt
       mergedBy {
@@ -45,8 +33,13 @@ mutation ReopenPullRequest ($pullRequestId: ID!) {
       }
       number
       permalink
+      repository {
+        id
+        url
+      }
       revertUrl
       state
+      title
     }
   }
 }

--- a/resources/graphql/update-pull-request-mutation.graphql
+++ b/resources/graphql/update-pull-request-mutation.graphql
@@ -6,42 +6,30 @@ mutation UpdatePullRequest ($pullRequestId: ID!, $title: String, $body: String) 
       body: $body
     }) {
     pullRequest {
-      id
-      title
-      body
-      baseRefOid
-      headRefOid
-      permalink
+      additions
       author {
         login
         url
       }
-      closed
-      isDraft
-      merged
-      mergeable
-      number
-      repository {
-        id
-        url
-      }
-      state
-      additions
-      deletions
+      baseRefOid
+      body
       changedFiles
       checksResourcePath
       closed
       closedAt
       createdAt
+      deletions
+      headRefOid
+      id
       isDraft
       maintainerCanModify
+      mergeable
       mergeCommit {
         abbreviatedOid
         message
         messageBody
         messageHeadline
       }
-      mergeable
       merged
       mergedAt
       mergedBy {
@@ -50,8 +38,13 @@ mutation UpdatePullRequest ($pullRequestId: ID!, $title: String, $body: String) 
       }
       number
       permalink
+      repository {
+        id
+        url
+      }
       revertUrl
       state
+      title
     }
   }
 }

--- a/src/eamonnsullivan/github_pr_lib.clj
+++ b/src/eamonnsullivan/github_pr_lib.clj
@@ -182,8 +182,7 @@
         (make-graphql-post access-token mutation merged-variables)))))
 
 
-(def create-pr-defaults {:draft true
-                         :maintainerCanModify true})
+(def create-pr-defaults {:draft true})
 
 (defn create-pull-request
   "Create a pull request on Github repository.
@@ -197,11 +196,9 @@
   * pull-request -- a map describing the pull
   request. Keys: :title, :base (the base branch), :branch (the branch
   you want to merge) and (if a URL isn't provided) the :owner (or
-  organisation) and :name of the repo. Optional keys
-  include :draft (default: true), indicating whether the pull request
-  is ready for review and :maintainerCanModify (default: true)
-  indicating whether the repo owner is allowed to modify the pull
-  request.
+  organisation) and :name of the repo. Optional key :draft
+  (default: true) indicates whether the pull request
+  is in a draft state and not ready for review.
 
   Returns a map describing the pull request,
   including :title, :body, :permalink, :additions, :deletions
@@ -219,16 +216,14 @@
           body :body
           base-branch :base
           merging-branch :branch
-          draft :draft
-          maintainerCanModify :maintainerCanModify} (merge create-pr-defaults pull-request)
+          draft :draft} (merge create-pr-defaults pull-request)
          repo-id (get-repo-id access-token owner repo-name)
          variables {:repositoryId repo-id
                     :title title
                     :body body
                     :base base-branch
                     :branch merging-branch
-                    :draft draft
-                    :maintainerCanModify maintainerCanModify}]
+                    :draft draft}]
      (when repo-id
        (-> (make-graphql-post access-token create-pull-request-mutation variables)
            :data

--- a/test/eamonnsullivan/github_pr_lib_test.clj
+++ b/test/eamonnsullivan/github_pr_lib_test.clj
@@ -54,15 +54,13 @@
   [payload]
   (testing "the draft and maintainerCanModfy parameters have a default"
     (let [variables (:variables (json/read-str payload :key-fn keyword))]
-      (is (= true (:draft variables)))
-      (is (= true (:maintainerCanModify variables))))))
+      (is (= true (:draft variables))))))
 
 (defn assert-payload-defaults-overridden
   [payload]
-  (testing "the draft and maintainerCanModify parameters can be overridden"
+  (testing "the draft parameter can be overridden"
     (let [variables (:variables (json/read-str payload :key-fn keyword))]
-      (is (= false (:draft variables)))
-      (is (= false (:maintainerCanModify variables))))))
+      (is (= false (:draft variables))))))
 
 (deftest test-create-pull-request
   (with-redefs [sut/http-post (make-fake-post repo-id-response-success create-pr-response-success nil nil)]
@@ -106,13 +104,6 @@
                                                :title "some title"
                                                :body "A body"
                                                :base "main"
-                                               :branch "new-stuff"}))
-    (testing "The maintainerCanModify option defaults to true"
-      (sut/create-pull-request "secret-token" {:owner "owner"
-                                               :name "repo-name"
-                                               :title "some title"
-                                               :body "A body"
-                                               :base "main"
                                                :branch "new-stuff"})))
   (with-redefs [sut/http-post (make-fake-post repo-id-response-success create-pr-response-success nil assert-payload-defaults-overridden)]
     (testing "The defaulted options can be overridden"
@@ -122,8 +113,7 @@
                                                :body "A body"
                                                :base "main"
                                                :branch "new-stuff"
-                                               :draft false
-                                               :maintainerCanModify false}))))
+                                               :draft false}))))
 
 
 (deftest test-parse-repo


### PR DESCRIPTION
- Remove redundant keys
- Alphabetise so I can spot this better next time
- Also, remove references to maintainerCanModify. It seems like we can't change this.